### PR TITLE
docs: correct typos in Kiichain Testnets README

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,10 +1,10 @@
-# Kiichain Testnets
+# KiiChain Testnets
 
-This repository stores information about the Kiichain Testnets.
+This repository stores information about the KiiChain Testnets.
 
 Here you will find information such as:
 
-- Gensisis file
+- Genesis file
 - Onboarding scripts
 - General chain information
 
@@ -52,7 +52,7 @@ You can get tokens to our Testnet Oro by using our Explorer app:
 
 - [KiiChain Explorer Faucet](https://explorer.kiichain.io/wallet/accounts)
 
-Our through our Discord channel:
+Or through our Discord channel:
 
 - [Discord Kiichain Invitation](https://discord.com/invite/kiichain)
 


### PR DESCRIPTION
- Fixed 'Gensisis' -> 'Genesis'
- Fixed redundant 'Our through our Discord channel'
- Standardized 'Kiichain' spelling to 'KiiChain'

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (updates documentation on the project)
- [ ] chore (Updates on dependencies, gitignore, etc)
- [ ] test (For updates on tests)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B