### PR TITLE
docs: Correct typos in KiiChain Testnets README

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,10 +1,10 @@
-# Kiichain Testnets
+# KiiChain Testnets
 
-This repository stores information about the Kiichain Testnets.
+This repository stores information about the KiiChain Testnets.
 
 Here you will find information such as:
 
-- Gensisis file
+- Genesis file
 - Onboarding scripts
 - General chain information
 
@@ -52,7 +52,7 @@ You can get tokens to our Testnet Oro by using our Explorer app:
 
 - [KiiChain Explorer Faucet](https://explorer.kiichain.io/wallet/accounts)
 
-Our through our Discord channel:
+Or through our Discord channel:
 
 - [Discord Kiichain Invitation](https://discord.com/invite/kiichain)
 


### PR DESCRIPTION
# Description

Correct typos in KiiChain Testnets README

## Type of change

Please delete options that are not relevant.
- [x] Documentation (updates documentation on the project)

# How Has This Been Tested?
- [x] Have been checked the documentation typos
- [x] Fixed 'Gensisis' -> 'Genesis'
- [x]  Fixed redundant 'Our through our Discord channel'
- [x]  Standardized 'Kiichain' spelling to 'KiiChain'
