### PR TITLE
Remove crisis flag from chain start-up scripts

### DIFF
--- a/testnet_oro/join_oro.sh
+++ b/testnet_oro/join_oro.sh
@@ -109,7 +109,7 @@ echo "After=network-online.target"          | sudo tee /etc/systemd/system/$SERV
 echo ""                                     | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo "[Service]"                            | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo "User=$USER"                           | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
-echo "ExecStart=$HOME/go/bin/$CHAIN_BINARY start --x-crisis-skip-assert-invariants --home $NODE_HOME --chain-id $CHAIN_ID" | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "ExecStart=$HOME/go/bin/$CHAIN_BINARY start --home $NODE_HOME --chain-id $CHAIN_ID" | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo "Restart=always"                       | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo "RestartSec=3"                         | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo "LimitNOFILE=4096"                     | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a

--- a/testnet_oro/join_oro_cv.sh
+++ b/testnet_oro/join_oro_cv.sh
@@ -130,7 +130,7 @@ echo "After=network-online.target"                       | sudo tee /etc/systemd
 echo ""                                                  | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo "[Service]"                                         | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo "User=$USER"                                        | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
-echo "ExecStart=$HOME/go/bin/cosmovisor run start --x-crisis-skip-assert-invariants --home $NODE_HOME --chain-id $CHAIN_ID" | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
+echo "ExecStart=$HOME/go/bin/cosmovisor run start --home $NODE_HOME --chain-id $CHAIN_ID" | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo "Restart=always"                                    | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo "RestartSec=3"                                      | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a
 echo "LimitNOFILE=50000"                                 | sudo tee /etc/systemd/system/$SERVICE_NAME.service -a


### PR DESCRIPTION
# Description

Remove crisis flag from start-up script

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (updates documentation on the project)
- [x] chore (Updates on dependencies, gitignore, etc)
- [ ] test (For updates on tests)
