### PR TITLE
Add KiiStablecoin ($KIIUSD) contract deployment by hunterkurfi

### DIFF
--- a/testnet_oro/KiiUSD_hunterkurfi.sol
+++ b/testnet_oro/KiiUSD_hunterkurfi.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/**
+ * @title KiiStablecoin
+ * @dev Simple Stablecoin implementation for KiiChain Builder Guide
+ */
+contract KiiStablecoin is ERC20, Ownable {
+    
+    // The constructor mints an initial supply to the deployer
+    // Name: Kii Dollar, Symbol: KIIUSD
+    constructor() ERC20("Kii Dollar", "KIIUSD") Ownable(msg.sender) {
+        _mint(msg.sender, 1000000 * 10 ** decimals());
+    }
+
+    /**
+     * @dev Function to mint more stablecoins. 
+     * Only the owner (you) can call this.
+     */
+    function mint(address to, uint256 amount) public onlyOwner {
+        _mint(to, amount);
+    }
+}

--- a/testnet_oro/assetlist.json
+++ b/testnet_oro/assetlist.json
@@ -536,6 +536,21 @@
         "location": "Australia",
         "total_shares": "6000"
       }
+    }    ,
+    {
+      "description": "Kii Dollar Stablecoin by hunterkurfi",
+      "denom_units": [
+        {
+          "denom": "kiiusd",
+          "exponent": 18
+        }
+      ],
+      "base": "kiiusd",
+      "name": "Kii Dollar",
+      "display": "kiiusd",
+      "symbol": "KIIUSD",
+      "address": "0x9002b809094927b54343eA785487484288Baf990"
     }
+
   ]
 }


### PR DESCRIPTION
This contract implements a simple stablecoin called Kii Dollar ($KIIUSD) with a total supply of 1,000,000 tokens minted to the deployer. It includes standard ERC20 functionality and Ownable access control for secure minting. This is part of my builder contribution to the KiiChain Oro Testnet. contract implements a simple stablecoin called KiiDollar with minting functionality for the owner.

# Description

Submission Details:
​Project: kiiUSD Stablecoin Deployment
​Contract Address: 0x9002b809094927b54343eA785487484288Baf990
​Activity: Successfully minted 1,000,000 $KIIUSD and tested transfers/minting to multiple wallets on the Oro Testnet.

## Type of change

- [X ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?


 deployed the contract using Remix IDE on the KiiChain Oro Testnet. After deployment, I successfully executed the following tests:
​Initial Mint: Minted 1,000,000 $KIIUSD to the deployer address.
​Transfer Test: Sent tokens to multiple external wallet addresses to verify ERC20 transfer functionality.
​Minting Test: Verified the onlyOwner mint function by minting additional tokens to a secondary wallet.