### PR TITLE
docs: proposal 28

### DIFF
--- a/testnet_oro/proposals/proposal_28.json
+++ b/testnet_oro/proposals/proposal_28.json
@@ -1,0 +1,76 @@
+{
+    "messages": [
+        {
+            "@type": "/ibc.applications.interchain_accounts.host.v1.MsgUpdateParams",
+            "signer": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
+            "params": {
+                "host_enabled": false,
+                "allow_messages": [
+                    "/cosmos.bank.v1beta1.MsgSend",
+                    "/cosmos.bank.v1beta1.MsgMultiSend",
+                    "/cosmos.distribution.v1beta1.MsgSetWithdrawAddress",
+                    "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission",
+                    "/cosmos.distribution.v1beta1.MsgFundCommunityPool",
+                    "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward",
+                    "/cosmos.gov.v1beta1.MsgVoteWeighted",
+                    "/cosmos.gov.v1beta1.MsgSubmitProposal",
+                    "/cosmos.gov.v1beta1.MsgDeposit",
+                    "/cosmos.gov.v1beta1.MsgVote",
+                    "/cosmos.staking.v1beta1.MsgEditValidator",
+                    "/cosmos.staking.v1beta1.MsgDelegate",
+                    "/cosmos.staking.v1beta1.MsgUndelegate",
+                    "/cosmos.staking.v1beta1.MsgBeginRedelegate",
+                    "/cosmos.staking.v1beta1.MsgCreateValidator",
+                    "/cosmos.vesting.v1beta1.MsgCreateVestingAccount"
+                ]
+            }
+        },
+        {
+            "@type": "/cosmos.evm.vm.v1.MsgUpdateParams",
+            "authority": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
+            "params": {
+                "evm_denom": "akii",
+                "extra_eips": [],
+                "evm_channels": [],
+                "access_control": {
+                    "create": {
+                        "access_type": "ACCESS_TYPE_PERMISSIONLESS",
+                        "access_control_list": []
+                    },
+                    "call": {
+                        "access_type": "ACCESS_TYPE_PERMISSIONLESS",
+                        "access_control_list": []
+                    }
+                },
+                "active_static_precompiles": [
+                    "0x0000000000000000000000000000000000000100",
+                    "0x0000000000000000000000000000000000000400",
+                    "0x0000000000000000000000000000000000000800",
+                    "0x0000000000000000000000000000000000000802",
+                    "0x0000000000000000000000000000000000000803",
+                    "0x0000000000000000000000000000000000000804",
+                    "0x0000000000000000000000000000000000000805",
+                    "0x0000000000000000000000000000000000000806",
+                    "0x0000000000000000000000000000000000001002",
+                    "0x0000000000000000000000000000000000001003"
+                ],
+                "history_serve_window": "0",
+                "extended_denom_options": {
+                    "extended_denom": "akii"
+                }
+            }
+        },
+        {
+            "@type": "/ibc.applications.interchain_accounts.controller.v1.MsgUpdateParams",
+            "signer": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
+            "params": {
+                "controller_enabled": false
+            }
+        }
+    ],
+    "metadata": "ipfs://CID",
+    "deposit": "10000000000000000000akii",
+    "title": "Restrict ICA Host allow messages, remove distribution precompile, and disable the ICA module",
+    "summary": "Restrict allow messages on IBC ICA Host to prevent potential security risks, remove the distribution precompile (0x0000000000000000000000000000000000000801) from the EVM active static precompiles, and disable the Interchain Accounts (ICA) module by turning off both the ICA Host (host_enabled=false) and ICA Controller (controller_enabled=false) submodules.",
+    "expedited": false
+}


### PR DESCRIPTION
# Description

Adds a new testnet governance proposal (`testnet_oro/proposals/proposal_28.json`) that disables the Interchain Accounts (ICA) module, which is currently unused on the network.

The proposal contains three `MsgUpdateParams` messages:

1. **ICA Host** (`/ibc.applications.interchain_accounts.host.v1.MsgUpdateParams`) — sets `host_enabled: false` to disable the ICA host submodule (carries forward the restricted `allow_messages` list from proposal 27, now moot since host is off).
2. **EVM VM** (`/cosmos.evm.vm.v1.MsgUpdateParams`) — unchanged from proposal 27 (keeps the distribution precompile `0x...0801` removed from the active static precompiles).
3. **ICA Controller** (`/ibc.applications.interchain_accounts.controller.v1.MsgUpdateParams`) — sets `controller_enabled: false` to disable the ICA controller submodule.

Disabling ICA is done purely via param changes (no binary/software upgrade required), so it takes effect immediately when the proposal passes. Both ICA submodules (host and controller) must be turned off to fully disable the module.

Motivation: ICA is not in use on the network, so it is being disabled to reduce surface area. This is the parameter-based approach; full code/state removal would require a separate software-upgrade with a store-deletion migration.

Dependencies: none.

## Type of change

- [x] chore (Updates on dependencies, gitignore, etc)

# How Has This Been Tested?

Submitted and voted on devnet (`plata_404-1`) as **proposal 32** via the standard Cosmos-SDK gov flow.

- [x] **Submission** — submitted `proposal_28.json` with `kiichaind tx gov submit-proposal`; auto-assigned proposal ID `32`, entered voting period (deposit `10000000000000000000akii` meets `min_deposit`).
  - Tx: `62DD376D3DAB17574DD1FAE8A15BA59A4FACFA03DD190E72CAA7B7B90B2986D9`
  - Proposal: https://lcd.plata-404.kiivalidator.com/cosmos/gov/v1/proposals/32
- [x] **Voting** — voted `yes` with both devnet validator keys (the majority of devnet stake), so the proposal passes at the end of the voting window.
  - `kii1d82mn4crgqdpe0fx4va2h6d6ywxdknsg89mc40` → tx `630E241AFB9AD1681FCEAFED8AF4D89EAF8F1FCEA5E3B2DBF99BB6A40BBE84FE`
  - `kii1hxjuanutlste73dupm8vmpjf9a3ltkvvya6wsl` → tx `3A34261F9C94FAA4F3438BBDF91D5E8425B32DA86994F0E9529D18CEE4553443`
  - Votes: https://lcd.plata-404.kiivalidator.com/cosmos/gov/v1/proposals/32/votes
  - Tally: https://lcd.plata-404.kiivalidator.com/cosmos/gov/v1/proposals/32/tally