### PR TITLE
docs: proposal 30

### DIFF
--- a/testnet_oro/proposals/proposal_30.json
+++ b/testnet_oro/proposals/proposal_30.json
@@ -1,0 +1,45 @@
+{
+    "messages": [
+        {
+            "@type": "/cosmos.evm.vm.v1.MsgUpdateParams",
+            "authority": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
+            "params": {
+                "evm_denom": "akii",
+                "extra_eips": [],
+                "evm_channels": [],
+                "access_control": {
+                    "create": {
+                        "access_type": "ACCESS_TYPE_PERMISSIONLESS",
+                        "access_control_list": []
+                    },
+                    "call": {
+                        "access_type": "ACCESS_TYPE_PERMISSIONLESS",
+                        "access_control_list": []
+                    }
+                },
+                "active_static_precompiles": [
+                    "0x0000000000000000000000000000000000000100",
+                    "0x0000000000000000000000000000000000000400",
+                    "0x0000000000000000000000000000000000000800",
+                    "0x0000000000000000000000000000000000000801",
+                    "0x0000000000000000000000000000000000000802",
+                    "0x0000000000000000000000000000000000000803",
+                    "0x0000000000000000000000000000000000000804",
+                    "0x0000000000000000000000000000000000000805",
+                    "0x0000000000000000000000000000000000000806",
+                    "0x0000000000000000000000000000000000001002",
+                    "0x0000000000000000000000000000000000001003"
+                ],
+                "history_serve_window": "0",
+                "extended_denom_options": {
+                    "extended_denom": "akii"
+                }
+            }
+        }
+    ],
+    "metadata": "ipfs://CID",
+    "deposit": "10000000000000000000akii",
+    "title": "Re-enable the distribution precompile on EVM",
+    "summary": "This proposal re-enables the distribution precompile (0x0000000000000000000000000000000000000801) on the EVM active static precompiles list.\n\nIt was removed in proposal 28 as a temporary mitigation for a supply-inflation bug when a non-20-byte withdraw address was mirrored into the EVM StateDB. That bug is fixed in v7.3.0 via a 20-byte address codec guard on the precompile path, so the precompile can safely be restored.\n\nRe-enabling it restores EVM access to staking reward withdrawal, validator commission withdrawal, and community pool funding.",
+    "expedited": false
+}


### PR DESCRIPTION
# Description

Adds `proposal_30.json` to re-enable the distribution precompile (`0x0000000000000000000000000000000000000801`) on Oro testnet.

This reverses the EVM half of proposal 28, which removed the precompile as a temporary mitigation for a supply-inflation bug when a non-20-byte withdraw address was mirrored into the EVM StateDB. That bug is fixed in v7.3.0 (20-byte address codec guard on the precompile path), and Oro is already past the v7.3.0 upgrade height, so the precompile can safely be restored.

The proposal is a single `MsgUpdateParams` that keeps all current Oro EVM params unchanged except adding `0x0801` back to `active_static_precompiles` (Oro's existing `0x1002` / `0x1003` entries are preserved). Deposit is the standard Oro `min_deposit` (10 KII); non-expedited.

No code or binary change — param change only. Mainnet equivalent is `proposal_8` in the mainnets repo (submit there only after mainnet v7.3.0 lands).

## Type of change

- [x] Documentation (updates documentation on the project)

# How Has This Been Tested?

- [x] Diffed proposed `active_static_precompiles` against live Oro LCD (`/cosmos/evm/vm/v1/params`) — only addition is `0x0801`
- [x] Confirmed Oro height is past the v7.3.0 upgrade (`proposal_29` / height `33659735`)
- [x] Validated JSON parses and precompile list is sorted