### PR TITLE
docs: proposal 31

### DIFF
--- a/testnet_oro/proposals/proposal_31.json
+++ b/testnet_oro/proposals/proposal_31.json
@@ -6,7 +6,7 @@
             "plan": {
                 "name": "v7.3.1",
                 "time": "0001-01-01T00:00:00Z",
-                "height": "34095400",
+                "height": "34098550",
                 "info": "",
                 "upgraded_client_state": null
             }
@@ -15,6 +15,6 @@
     "metadata": "ipfs://CID",
     "deposit": "10000000000000000000akii",
     "title": "Upgrade Kiichain Testnet Oro to v7.3.1",
-    "summary": "Upgrade Kiichain Testnet Oro to v7.3.1.\n- Keeps the gov module account on the bank blocked list so EVM BalanceHandler does not mirror gov deposits into StateDB (fixes Safe → gov precompile deposit failing on commit with unauthorized).\n- Release: https://github.com/KiiChain/kiichain/releases/tag/v7.3.1\n- PR: https://github.com/KiiChain/kiichain/pull/368\n- Changelog: https://github.com/KiiChain/kiichain/blob/v7.3.1/CHANGELOG.md\n- Target time ~2026-08-10T14:00:00Z (Monday; moved off Saturday per ops feedback; measured block time ~2.61s).",
+    "summary": "Upgrade Kiichain Testnet Oro to v7.3.1.\n- Release (binaries + checksums): https://github.com/KiiChain/kiichain/releases/tag/v7.3.1\n- linux/amd64 sha256: 77325385a0f3b080900e471f2f625c73390be1fd7ad234ad0904ee192927e312\n- Changelog: https://github.com/KiiChain/kiichain/blob/v7.3.1/CHANGELOG.md",
     "expedited": false
 }

--- a/testnet_oro/proposals/proposal_31.json
+++ b/testnet_oro/proposals/proposal_31.json
@@ -1,0 +1,20 @@
+{
+    "messages": [
+        {
+            "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+            "authority": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
+            "plan": {
+                "name": "v7.3.1",
+                "time": "0001-01-01T00:00:00Z",
+                "height": "34027700",
+                "info": "",
+                "upgraded_client_state": null
+            }
+        }
+    ],
+    "metadata": "ipfs://CID",
+    "deposit": "10000000000000000000akii",
+    "title": "Upgrade Kiichain Testnet Oro to v7.3.1",
+    "summary": "Upgrade Kiichain Testnet Oro to v7.3.1.\n- Keeps the gov module account on the bank blocked list so EVM BalanceHandler does not mirror gov deposits into StateDB (fixes Safe → gov precompile deposit failing on commit with unauthorized).\n- Release: https://github.com/KiiChain/kiichain/releases/tag/v7.3.1\n- PR: https://github.com/KiiChain/kiichain/pull/368\n- Changelog: https://github.com/KiiChain/kiichain/blob/v7.3.1/CHANGELOG.md\n- Target time ~2026-08-08T13:53:00Z (~48h lead = 12h voting + ~36h validator staging; measured block time ~2.66s).",
+    "expedited": false
+}

--- a/testnet_oro/proposals/proposal_31.json
+++ b/testnet_oro/proposals/proposal_31.json
@@ -6,7 +6,7 @@
             "plan": {
                 "name": "v7.3.1",
                 "time": "0001-01-01T00:00:00Z",
-                "height": "34027700",
+                "height": "34095400",
                 "info": "",
                 "upgraded_client_state": null
             }
@@ -15,6 +15,6 @@
     "metadata": "ipfs://CID",
     "deposit": "10000000000000000000akii",
     "title": "Upgrade Kiichain Testnet Oro to v7.3.1",
-    "summary": "Upgrade Kiichain Testnet Oro to v7.3.1.\n- Keeps the gov module account on the bank blocked list so EVM BalanceHandler does not mirror gov deposits into StateDB (fixes Safe → gov precompile deposit failing on commit with unauthorized).\n- Release: https://github.com/KiiChain/kiichain/releases/tag/v7.3.1\n- PR: https://github.com/KiiChain/kiichain/pull/368\n- Changelog: https://github.com/KiiChain/kiichain/blob/v7.3.1/CHANGELOG.md\n- Target time ~2026-08-08T13:53:00Z (~48h lead = 12h voting + ~36h validator staging; measured block time ~2.66s).",
+    "summary": "Upgrade Kiichain Testnet Oro to v7.3.1.\n- Keeps the gov module account on the bank blocked list so EVM BalanceHandler does not mirror gov deposits into StateDB (fixes Safe → gov precompile deposit failing on commit with unauthorized).\n- Release: https://github.com/KiiChain/kiichain/releases/tag/v7.3.1\n- PR: https://github.com/KiiChain/kiichain/pull/368\n- Changelog: https://github.com/KiiChain/kiichain/blob/v7.3.1/CHANGELOG.md\n- Target time ~2026-08-10T14:00:00Z (Monday; moved off Saturday per ops feedback; measured block time ~2.61s).",
     "expedited": false
 }


### PR DESCRIPTION
# Description

Adds Oro testnet software-upgrade proposal **31** for **v7.3.1**.

This upgrades Testnet Oro to pick up the gov module bank-block fix so EVM `BalanceHandler` does not mirror gov deposits into StateDB (fixes Safe → gov precompile `deposit` failing on commit with `unauthorized`).

- Proposal JSON: `testnet_oro/proposals/proposal_31.json`
- Plan name: `v7.3.1`
- Height: `34027700` (~2026-08-08T13:53:00Z; ~48h lead)
- Next on-chain proposal ID: **31** (latest is 30)
- Chain: `kiichain` release/tag: https://github.com/KiiChain/kiichain/releases/tag/v7.3.1
- Fix PR: https://github.com/KiiChain/kiichain/pull/368
- Changelog: https://github.com/KiiChain/kiichain/blob/v7.3.1/CHANGELOG.md

Depends on validators staging `v7.3.1` under cosmovisor before the upgrade height.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation (updates documentation on the project)
- [ ] chore (Updates on dependencies, gitignore, etc)
- [ ] test (For updates on tests)

# How Has This Been Tested?

- [x] Confirmed on-chain Oro latest proposal is **30**, so next ID is **31**
- [x] Proposal JSON matches prior Oro upgrade proposal format (`proposal_29` / v7.3.0)
- [x] Fix validated on Devnet Plata (proposal 36 submitted/voted; `v7.3.1` staged on both validators)
- [ ] Submit + vote Oro proposal 31 after this PR merges
- [ ] Stage `v7.3.1` on Oro validators via cosmovisor before height `34027700`