### PR TITLE
docs: proposal 32

### DIFF
--- a/testnet_oro/proposals/proposal_32.json
+++ b/testnet_oro/proposals/proposal_32.json
@@ -1,0 +1,17 @@
+{
+    "messages": [
+        {
+            "@type": "/cosmos.evm.erc20.v1.MsgUpdateParams",
+            "authority": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
+            "params": {
+                "enable_erc20": true,
+                "permissionless_registration": false
+            }
+        }
+    ],
+    "metadata": "ipfs://CID",
+    "deposit": "10000000000000000000akii",
+    "title": "Disable permissionless ERC20 registration",
+    "summary": "Disable permissionless ERC20 token pair registration. After this change, only governance can register ERC20 contracts as token pairs. ERC20 conversion remains enabled.",
+    "expedited": false
+}


### PR DESCRIPTION
# Description

Adds Testnet Oro governance proposal 32 to disable permissionless ERC20 token pair registration.

The proposal sends `cosmos.evm.erc20.v1.MsgUpdateParams` with authority set to the gov module account (`kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv`) and params:

- `enable_erc20`: `true` (conversion stays enabled)
- `permissionless_registration`: `false` (only governance can register ERC20 token pairs)

This matches the message already submitted on Devnet Plata (proposal 39). Deposit is `10000000000000000000akii` (Oro min deposit). No chain upgrade or binary dependency is required for this params change.

## Type of change

- [x] Documentation (updates documentation on the project)

# How Has This Been Tested?

- [x] Queried `/cosmos/evm/erc20/v1/params` on Plata, Oro, and mainnet; all currently have `permissionless_registration: true`
- [x] Encoded the proposal with `kiichaind tx gov submit-proposal --generate-only` and confirmed `MsgUpdateParams` payload
- [x] Submitted the same proposal on Devnet Plata as proposal 39, voted yes from both validators, and confirmed it entered `VOTING_PERIOD` with a full yes tally