### PR TITLE
docs: disable cosmwasm

### DIFF
--- a/testnet_oro/proposals/proposal_33.json
+++ b/testnet_oro/proposals/proposal_33.json
@@ -1,0 +1,20 @@
+{
+    "messages": [
+        {
+            "@type": "/cosmwasm.wasm.v1.MsgUpdateParams",
+            "authority": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
+            "params": {
+                "code_upload_access": {
+                    "permission": "Nobody",
+                    "addresses": []
+                },
+                "instantiate_default_permission": "Nobody"
+            }
+        }
+    ],
+    "metadata": "ipfs://CID",
+    "deposit": "10000000000000000000akii",
+    "title": "Disable the CosmWasm module",
+    "summary": "Disable the CosmWasm module by setting code upload access and the default instantiate permission to Nobody. After this change, no new CosmWasm code can be uploaded and no new contracts can be instantiated.",
+    "expedited": false
+}


### PR DESCRIPTION
# Description

Adds Testnet Oro governance proposal 33 to disable the CosmWasm module.

The proposal sends `cosmwasm.wasm.v1.MsgUpdateParams` with authority set to the gov module account (`kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv`) and params:

- `code_upload_access.permission`: `Nobody` (no new CosmWasm code uploads)
- `instantiate_default_permission`: `Nobody` (no new contract instantiations)

This matches the CosmWasm disable proposal already submitted on Devnet Plata (proposal 41). Deposit is `10000000000000000000akii` (Oro min deposit). No chain upgrade or binary dependency is required for this params change.

## Type of change

- [x] Documentation (updates documentation on the project)

# How Has This Been Tested?

- [x] Confirmed latest Oro on-chain proposal is 32 (`PROPOSAL_STATUS_PASSED`)
- [x] Queried `/cosmwasm/wasm/v1/codes/params` on Oro; currently `Everybody` / `Everybody`
- [x] Submitted the same payload on Devnet Plata as proposal 41, voted yes from both validators, and confirmed it entered `VOTING_PERIOD`