### PR TITLE
docs: proposal 34

### DIFF
--- a/testnet_oro/proposals/proposal_34.json
+++ b/testnet_oro/proposals/proposal_34.json
@@ -6,7 +6,7 @@
             "plan": {
                 "name": "v7.4.0",
                 "time": "0001-01-01T00:00:00Z",
-                "height": "34983400",
+                "height": "35048447",
                 "info": "",
                 "upgraded_client_state": null
             }

--- a/testnet_oro/proposals/proposal_34.json
+++ b/testnet_oro/proposals/proposal_34.json
@@ -1,0 +1,20 @@
+{
+    "messages": [
+        {
+            "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+            "authority": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
+            "plan": {
+                "name": "v7.4.0",
+                "time": "0001-01-01T00:00:00Z",
+                "height": "34983400",
+                "info": "",
+                "upgraded_client_state": null
+            }
+        }
+    ],
+    "metadata": "ipfs://CID",
+    "deposit": "10000000000000000000akii",
+    "title": "Upgrade Kiichain Testnet Oro to v7.4.0",
+    "summary": "Upgrade Kiichain Testnet Oro to v7.4.0.\n- Release (binaries + checksums): https://github.com/KiiChain/kiichain/releases/tag/v7.4.0\n- linux/amd64 sha256: d721a394d09887266a455fe82d05e690171ee2e5850a1a557fb8e0f264a1dc30\n- Changelog: https://github.com/KiiChain/kiichain/blob/v7.4.0/CHANGELOG.md",
+    "expedited": false
+}


### PR DESCRIPTION
# Description

Adds Oro testnet software-upgrade proposal **34** for **v7.4.0**.

- Proposal JSON: `testnet_oro/proposals/proposal_34.json`
- Plan name: `v7.4.0`
- Height: `34983400` (~2026-09-08T17:00:00Z Tue; weekday target, avoids weekend)
- Next on-chain proposal ID: **34** (latest is 33)
- Release: https://github.com/KiiChain/kiichain/releases/tag/v7.4.0
- linux/amd64 sha256: `d721a394d09887266a455fe82d05e690171ee2e5850a1a557fb8e0f264a1dc30`
- Changelog: https://github.com/KiiChain/kiichain/blob/v7.4.0/CHANGELOG.md

Depends on validators staging `v7.4.0` under cosmovisor before the upgrade height. Voting period is 12h; submit Monday so the height falls after vote on a weekday.

## Type of change

- [x] Documentation (updates documentation on the project)

# How Has This Been Tested?

- [x] Confirmed on-chain Oro latest proposal is **33**, so next ID is **34**
- [x] Proposal JSON matches prior Oro upgrade proposal format (`proposal_31` / v7.3.1)
- [x] Staged `v7.4.0` release binary on Oro validators and sentries under `cosmovisor/upgrades/v7.4.0/`
- [ ] Submit + vote Oro proposal 34 after this PR merges
- [ ] Confirm height still lands ~Tue 17:00 UTC at submit time (retarget if needed)