### PR TITLE
docs: proposal 35

### DIFF
--- a/testnet_oro/proposals/proposal_35.json
+++ b/testnet_oro/proposals/proposal_35.json
@@ -1,38 +1,6 @@
 {
     "messages": [
         {
-            "@type": "/cosmos.gov.v1.MsgUpdateParams",
-            "authority": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
-            "params": {
-                "min_deposit": [
-                    {
-                        "denom": "akii",
-                        "amount": "10000000000000000000"
-                    }
-                ],
-                "max_deposit_period": "172800s",
-                "voting_period": "345600s",
-                "quorum": "0.334000000000000000",
-                "threshold": "0.500000000000000000",
-                "veto_threshold": "0.334000000000000000",
-                "min_initial_deposit_ratio": "0.000000000000000000",
-                "proposal_cancel_ratio": "0.500000000000000000",
-                "proposal_cancel_dest": "",
-                "expedited_voting_period": "43000s",
-                "expedited_threshold": "0.667000000000000000",
-                "expedited_min_deposit": [
-                    {
-                        "denom": "akii",
-                        "amount": "20000000000000000000"
-                    }
-                ],
-                "burn_vote_quorum": false,
-                "burn_proposal_deposit_prevote": false,
-                "burn_vote_veto": true,
-                "min_deposit_ratio": "0.010000000000000000"
-            }
-        },
-        {
             "@type": "/ratelimit.v1.MsgAddRateLimit",
             "authority": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
             "denom": "akii",
@@ -71,7 +39,7 @@
     ],
     "metadata": "ipfs://CID",
     "deposit": "10000000000000000000akii",
-    "title": "Set 4-day voting and rate-limit akii IBC",
-    "summary": "1) Set governance voting_period to 4 days (345600s).\n2) Add IBC rate limits for native $KII (akii) at 0.1% send / 0.1% recv over 24h on transfer channel-0 through channel-3.",
+    "title": "Rate-limit akii IBC",
+    "summary": "Add IBC rate limits for native $KII (akii) at 0.1% send / 0.1% recv over 24h on transfer channel-0 through channel-3. Leaves the existing testnet voting period unchanged.",
     "expedited": false
 }

--- a/testnet_oro/proposals/proposal_35.json
+++ b/testnet_oro/proposals/proposal_35.json
@@ -33,15 +33,6 @@
             }
         },
         {
-            "@type": "/cosmos.gov.v1.MsgExecLegacyContent",
-            "authority": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
-            "content": {
-                "@type": "/cosmos.gov.v1beta1.TextProposal",
-                "title": "Authorize canonical ERC-4337 EntryPoint (and account factory) deployment",
-                "description": "Authorize deploying ERC-4337 EntryPoint v0.7 at the canonical CREATE2 address 0x0000000071727De22E5E9d8BAf0edAc6f37da032, and deploying the associated SimpleAccountFactory for use with that EntryPoint.\n\nThis matches the industry-standard deterministic address used by explorers (e.g. Blockscout) to attach User Operations to transactions. After deployment, bundler/paymaster configs should point at this EntryPoint."
-            }
-        },
-        {
             "@type": "/ratelimit.v1.MsgAddRateLimit",
             "authority": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
             "denom": "akii",
@@ -80,7 +71,7 @@
     ],
     "metadata": "ipfs://CID",
     "deposit": "10000000000000000000akii",
-    "title": "Set 4-day voting, authorize canonical EntryPoint, and rate-limit akii IBC",
-    "summary": "1) Set governance voting_period to 4 days (345600s).\n2) Authorize deploying ERC-4337 EntryPoint v0.7 at the canonical CREATE2 address 0x0000000071727De22E5E9d8BAf0edAc6f37da032 (and the associated account factory) so explorers can index UserOperations.\n3) Add IBC rate limits for native $KII (akii) at 10% send / 10% recv over 24h on transfer channel-0 through channel-3.",
+    "title": "Set 4-day voting and rate-limit akii IBC",
+    "summary": "1) Set governance voting_period to 4 days (345600s).\n2) Add IBC rate limits for native $KII (akii) at 10% send / 10% recv over 24h on transfer channel-0 through channel-3.",
     "expedited": false
 }

--- a/testnet_oro/proposals/proposal_35.json
+++ b/testnet_oro/proposals/proposal_35.json
@@ -37,8 +37,8 @@
             "authority": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
             "denom": "akii",
             "channel_or_client_id": "channel-0",
-            "max_percent_send": "10",
-            "max_percent_recv": "10",
+            "max_percent_send": "0.1",
+            "max_percent_recv": "0.1",
             "duration_hours": 24
         },
         {
@@ -46,8 +46,8 @@
             "authority": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
             "denom": "akii",
             "channel_or_client_id": "channel-1",
-            "max_percent_send": "10",
-            "max_percent_recv": "10",
+            "max_percent_send": "0.1",
+            "max_percent_recv": "0.1",
             "duration_hours": 24
         },
         {
@@ -55,8 +55,8 @@
             "authority": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
             "denom": "akii",
             "channel_or_client_id": "channel-2",
-            "max_percent_send": "10",
-            "max_percent_recv": "10",
+            "max_percent_send": "0.1",
+            "max_percent_recv": "0.1",
             "duration_hours": 24
         },
         {
@@ -64,14 +64,14 @@
             "authority": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
             "denom": "akii",
             "channel_or_client_id": "channel-3",
-            "max_percent_send": "10",
-            "max_percent_recv": "10",
+            "max_percent_send": "0.1",
+            "max_percent_recv": "0.1",
             "duration_hours": 24
         }
     ],
     "metadata": "ipfs://CID",
     "deposit": "10000000000000000000akii",
     "title": "Set 4-day voting and rate-limit akii IBC",
-    "summary": "1) Set governance voting_period to 4 days (345600s).\n2) Add IBC rate limits for native $KII (akii) at 10% send / 10% recv over 24h on transfer channel-0 through channel-3.",
+    "summary": "1) Set governance voting_period to 4 days (345600s).\n2) Add IBC rate limits for native $KII (akii) at 0.1% send / 0.1% recv over 24h on transfer channel-0 through channel-3.",
     "expedited": false
 }

--- a/testnet_oro/proposals/proposal_35.json
+++ b/testnet_oro/proposals/proposal_35.json
@@ -1,0 +1,86 @@
+{
+    "messages": [
+        {
+            "@type": "/cosmos.gov.v1.MsgUpdateParams",
+            "authority": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
+            "params": {
+                "min_deposit": [
+                    {
+                        "denom": "akii",
+                        "amount": "10000000000000000000"
+                    }
+                ],
+                "max_deposit_period": "172800s",
+                "voting_period": "345600s",
+                "quorum": "0.334000000000000000",
+                "threshold": "0.500000000000000000",
+                "veto_threshold": "0.334000000000000000",
+                "min_initial_deposit_ratio": "0.000000000000000000",
+                "proposal_cancel_ratio": "0.500000000000000000",
+                "proposal_cancel_dest": "",
+                "expedited_voting_period": "43000s",
+                "expedited_threshold": "0.667000000000000000",
+                "expedited_min_deposit": [
+                    {
+                        "denom": "akii",
+                        "amount": "20000000000000000000"
+                    }
+                ],
+                "burn_vote_quorum": false,
+                "burn_proposal_deposit_prevote": false,
+                "burn_vote_veto": true,
+                "min_deposit_ratio": "0.010000000000000000"
+            }
+        },
+        {
+            "@type": "/cosmos.gov.v1.MsgExecLegacyContent",
+            "authority": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
+            "content": {
+                "@type": "/cosmos.gov.v1beta1.TextProposal",
+                "title": "Authorize canonical ERC-4337 EntryPoint (and account factory) deployment",
+                "description": "Authorize deploying ERC-4337 EntryPoint v0.7 at the canonical CREATE2 address 0x0000000071727De22E5E9d8BAf0edAc6f37da032, and deploying the associated SimpleAccountFactory for use with that EntryPoint.\n\nThis matches the industry-standard deterministic address used by explorers (e.g. Blockscout) to attach User Operations to transactions. After deployment, bundler/paymaster configs should point at this EntryPoint."
+            }
+        },
+        {
+            "@type": "/ratelimit.v1.MsgAddRateLimit",
+            "authority": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
+            "denom": "akii",
+            "channel_or_client_id": "channel-0",
+            "max_percent_send": "10",
+            "max_percent_recv": "10",
+            "duration_hours": 24
+        },
+        {
+            "@type": "/ratelimit.v1.MsgAddRateLimit",
+            "authority": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
+            "denom": "akii",
+            "channel_or_client_id": "channel-1",
+            "max_percent_send": "10",
+            "max_percent_recv": "10",
+            "duration_hours": 24
+        },
+        {
+            "@type": "/ratelimit.v1.MsgAddRateLimit",
+            "authority": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
+            "denom": "akii",
+            "channel_or_client_id": "channel-2",
+            "max_percent_send": "10",
+            "max_percent_recv": "10",
+            "duration_hours": 24
+        },
+        {
+            "@type": "/ratelimit.v1.MsgAddRateLimit",
+            "authority": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
+            "denom": "akii",
+            "channel_or_client_id": "channel-3",
+            "max_percent_send": "10",
+            "max_percent_recv": "10",
+            "duration_hours": 24
+        }
+    ],
+    "metadata": "ipfs://CID",
+    "deposit": "10000000000000000000akii",
+    "title": "Set 4-day voting, authorize canonical EntryPoint, and rate-limit akii IBC",
+    "summary": "1) Set governance voting_period to 4 days (345600s).\n2) Authorize deploying ERC-4337 EntryPoint v0.7 at the canonical CREATE2 address 0x0000000071727De22E5E9d8BAf0edAc6f37da032 (and the associated account factory) so explorers can index UserOperations.\n3) Add IBC rate limits for native $KII (akii) at 10% send / 10% recv over 24h on transfer channel-0 through channel-3.",
+    "expedited": false
+}


### PR DESCRIPTION
# Description

Adds Oro testnet governance proposal 35:
- Add 0.1%/0.1% 24h IBC rate limits for `akii` on transfer channel-0 through channel-3
- Does **not** change the testnet voting period (stays at the current short window)

## Type of change

- [x] Documentation (updates documentation on the project)

# How Has This Been Tested?

- [x] JSON validated
- [ ] Submitted on-chain (after merge)
