### PR TITLE
docs: Oro proposal 36 rate-limit akii IBC

### DIFF
--- a/testnet_oro/proposals/proposal_36.json
+++ b/testnet_oro/proposals/proposal_36.json
@@ -1,0 +1,45 @@
+{
+    "messages": [
+        {
+            "@type": "/ratelimit.v1.MsgAddRateLimit",
+            "authority": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
+            "denom": "akii",
+            "channel_or_client_id": "channel-0",
+            "max_percent_send": "1",
+            "max_percent_recv": "1",
+            "duration_hours": 48
+        },
+        {
+            "@type": "/ratelimit.v1.MsgAddRateLimit",
+            "authority": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
+            "denom": "akii",
+            "channel_or_client_id": "channel-1",
+            "max_percent_send": "1",
+            "max_percent_recv": "1",
+            "duration_hours": 48
+        },
+        {
+            "@type": "/ratelimit.v1.MsgAddRateLimit",
+            "authority": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
+            "denom": "akii",
+            "channel_or_client_id": "channel-2",
+            "max_percent_send": "1",
+            "max_percent_recv": "1",
+            "duration_hours": 48
+        },
+        {
+            "@type": "/ratelimit.v1.MsgAddRateLimit",
+            "authority": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
+            "denom": "akii",
+            "channel_or_client_id": "channel-3",
+            "max_percent_send": "1",
+            "max_percent_recv": "1",
+            "duration_hours": 48
+        }
+    ],
+    "metadata": "ipfs://CID",
+    "deposit": "10000000000000000000akii",
+    "title": "Rate-limit akii IBC",
+    "summary": "Add IBC rate limits for native $KII (akii) at 1% send / 1% recv over 48h on transfer channel-0 through channel-3. Leaves the existing testnet voting period unchanged.",
+    "expedited": false
+}


### PR DESCRIPTION
# Description

Adds Oro testnet governance proposal 36 (submitted on-chain):
- 1% send / 1% recv IBC rate limits for `akii` over 48h on transfer channel-0 through channel-3
- Does not change the testnet voting period

## Type of change

- [x] Documentation (updates documentation on the project)

# How Has This Been Tested?

- [x] JSON matches on-chain proposal 36
- [x] Submitted and voting on Oro
