### PR TITLE
docs: add proposal 38 — Arachnid CREATE2 preinstall

### DIFF
--- a/testnet_oro/proposals/proposal_38.json
+++ b/testnet_oro/proposals/proposal_38.json
@@ -1,0 +1,20 @@
+{
+    "messages": [
+        {
+            "@type": "/cosmos.evm.vm.v1.MsgRegisterPreinstalls",
+            "authority": "kii10d07y265gmmuvt4z0w9aw880jnsr700jrff0qv",
+            "preinstalls": [
+                {
+                    "name": "Arachnid Deterministic Deployment Proxy",
+                    "address": "0x4e59b44847b379578588920ca78fbf26c0b4956c",
+                    "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b80825250506014600cf3"
+                }
+            ]
+        }
+    ],
+    "metadata": "ipfs://CID",
+    "deposit": "10000000000000000000akii",
+    "title": "Register Arachnid Deterministic Deployment Proxy",
+    "summary": "Preinstall Arachnid's CREATE2 factory at the canonical address 0x4e59b44847b379578588920ca78fbf26c0b4956c.\n\nThis is the standard deterministic deployment proxy used across EVM networks. Registering it via governance enables CREATE2 deployments at the same addresses as Ethereum (including the canonical ERC-4337 EntryPoint v0.7).\n\nVerified on Plata (devnet) before this testnet proposal.",
+    "expedited": false
+}


### PR DESCRIPTION
# Description

Adds governance proposal JSON to preinstall Arachnid's CREATE2 factory on Oro testnet at the canonical address `0x4e59b44847b379578588920ca78fbf26c0b4956c`.

## Type of change

- [x] Documentation (updates documentation on the project)

# How Has This Been Tested?

- [x] Proposal JSON matches the Plata `MsgRegisterPreinstalls` format that was submitted and verified on-chain
- [x] Preinstall address and bytecode match the canonical Arachnid deterministic deployment proxy
